### PR TITLE
Changed build_call to return a list

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -17,7 +17,7 @@
 #' @param end_date character string; end date
 #' @param service_type character string; file format (csv or xml)
 #' @param api_version character string; version of the api to use (currently on v1)
-#' @return character string; created url for the call
+#' @return list; created url for the call, service type and data item
 #' @family call-building functions
 #' @export
 #' @examples
@@ -26,40 +26,43 @@
 build_b_call <- function(data_item, api_key, settlement_date = NULL, period = NULL,
                          year = NULL, month = NULL, week = NULL, process_type = NULL, start_time = NULL,
                          end_time = NULL, start_date = NULL, end_date = NULL, service_type = "csv", api_version = "v1") {
-  url = paste0("https://api.bmreports.com/BMRS/", data_item, "/", api_version, "?APIKey=", api_key)
+  request <- list()
+  request$url = paste0("https://api.bmreports.com/BMRS/", data_item, "/", api_version, "?APIKey=", api_key)
   check_data_item(data_item, "B Flow")
   if (!is.null(settlement_date)) {
-    url = paste0(url, "&SettlementDate=", format_date(settlement_date))
+    request$url = paste0(request$url, "&SettlementDate=", format_date(settlement_date))
   }
   if (!is.null(period)){
-    url = paste0(url, "&Period=", period)
+    request$url = paste0(request$url, "&Period=", period)
   }
   if (!is.null(process_type)){
-    url = paste0(url, "&ProcessType", process_type)
+    request$url = paste0(request$url, "&ProcessType", process_type)
   }
   if (!is.null(year)){
-    url = paste0(url, "&Year=", year)
+    request$url = paste0(request$url, "&Year=", year)
   }
   if (!is.null(month)){
-    url = paste0(url, "&Month=", format_month(month))
+    request$url = paste0(request$url, "&Month=", format_month(month))
   }
   if (!is.null(week)){
-    url = paste0(url, "&Week=", week)
+    request$url = paste0(request$url, "&Week=", week)
   }
   if (!is.null(start_date)){
-    url = paste0(url, "&StartDate=", format_date(start_date))
+    request$url = paste0(request$url, "&StartDate=", format_date(start_date))
   }
   if (!is.null(end_date)){
-    url = paste0(url, "&EndDate=", format_date(end_date))
+    request$url = paste0(request$url, "&EndDate=", format_date(end_date))
   }
   if (!is.null(start_time)){
-    url = paste0(url, "&StartTime=", format_time(start_time))
+    request$url = paste0(request$url, "&StartTime=", format_time(start_time))
   }
   if (!is.null(end_time)){
-    url = paste0(url, "&EndTime=", format_time(end_time))
+    request$url = paste0(request$url, "&EndTime=", format_time(end_time))
   }
-  url = paste0(url, "&ServiceType=", service_type)
-  return(url)
+  request$url = paste0(request$url, "&ServiceType=", service_type)
+  request$service_type <- service_type
+  request$data_item <- data_item
+  return(request)
 }
 
 #' Create an API call for REMIT flows
@@ -81,7 +84,7 @@ build_b_call <- function(data_item, api_key, settlement_date = NULL, period = NU
 #' @param sequence_id character string; sequence id
 #' @param service_type character string; file format (csv or xml)
 #' @param api_version character string; version of the api to use (currently on v1)
-#' @return string; created url for the call
+#' @return list; created url for the call, service type and data item
 #' @family call-building functions
 #' @examples
 #' build_remit_call(data_item = "MessageListRetrieval", api_key = "12345", event_start = "14-12-2016", event_end = "15-12-2016")
@@ -90,55 +93,58 @@ build_b_call <- function(data_item, api_key, settlement_date = NULL, period = NU
 build_remit_call <- function(data_item, api_key, event_start = NULL, event_end = NULL, publication_from = NULL, publication_to = NULL,
                              participant_id = NULL, asset_id =  NULL, event_type = NULL, fuel_type = NULL, message_type = NULL, message_id = NULL,
                              unavailability_type =  NULL, active_flag = NULL, sequence_id = NULL, service_type = "xml", api_version = "v1"){
+  request <- list()
   check_data_item(data_item, "REMIT")
-  url = paste0("https://api.bmreports.com/BMRS/", data_item, "/", api_version, "?APIKey=", api_key)
+  request$url = paste0("https://api.bmreports.com/BMRS/", data_item, "/", api_version, "?APIKey=", api_key)
   if (service_type == "csv"){
     warning("Remit files cannot be returned as .csv - file will be returned as xml")
-    service_type = "xml"
+    service_type <- "xml"
   }
   if (!is.null(event_start)) {
-    url = paste0(url, "&EventStart=", format_date(event_start))
+    request$url = paste0(request$url, "&EventStart=", format_date(event_start))
   }
   if (!is.null(event_end)) {
-    url = paste0(url, "&EventEnd=", format_date(event_end))
+    request$url = paste0(request$url, "&EventEnd=", format_date(event_end))
   }
   if (!is.null(publication_from)) {
-    url = paste0(url, "&PublicationFrom=", format_date(publication_from))
+    request$url = paste0(request$url, "&PublicationFrom=", format_date(publication_from))
   }
   if (!is.null(publication_to)) {
-    url = paste0(url, "&PublicationTo=", format_date(publication_to))
+    request$url = paste0(request$url, "&PublicationTo=", format_date(publication_to))
   }
   if (!is.null(participant_id)) {
-    url = paste0(url, "&ParticipantID=", participant_id)
+    request$url = paste0(request$url, "&ParticipantID=", participant_id)
   }
   if (!is.null(asset_id)) {
-    url = paste0(url, "&AssetID=", asset_id)
+    request$url = paste0(request$url, "&AssetID=", asset_id)
   }
   if (!is.null(event_type)) {
-    url = paste0(url, "&EventType=", event_type)
+    request$url = paste0(request$url, "&EventType=", event_type)
   }
   if (!is.null(fuel_type)) {
-    url = paste0(url, "&FuelType=", fuel_type)
+    request$url = paste0(request$url, "&FuelType=", fuel_type)
   }
   if (!is.null(message_type)) {
-    url = paste0(url, "&MessageType=", message_type)
+    request$url = paste0(request$url, "&MessageType=", message_type)
   }
   if (!is.null(message_id)) {
-    url = paste0(url, "&MessageID=", message_id)
+    request$url = paste0(request$url, "&MessageID=", message_id)
   }
   if (!is.null(unavailability_type)) {
-    url = paste0(url, "&UnavailabilityType=", unavailability_type)
+    request$url = paste0(request$url, "&UnavailabilityType=", unavailability_type)
   }
   if (!is.null(active_flag)) {
-    url = paste0(url, "&ActiveFlag=", active_flag)
+    request$url = paste0(request$url, "&ActiveFlag=", active_flag)
   }
   if (!is.null(sequence_id)) {
-    url = paste0(url, "&SequenceId=", sequence_id)
+    request$url = paste0(request$url, "&SequenceId=", sequence_id)
   }
   if (!is.null(service_type)){
-    url = paste0(url, "&ServiceType=", service_type)
+    request$url = paste0(request$url, "&ServiceType=", service_type)
   }
-  return(url)
+  request$service_type <- service_type
+  request$data_item <- data_item
+  return(request)
 }
 
 #' Create an API call for legacy data
@@ -170,7 +176,7 @@ build_remit_call <- function(data_item, api_key, event_start = NULL, event_end =
 #' @param trade_type character string; trade type
 #' @param service_type character string; file format (csv or xml)
 #' @param api_version character string; version of the api to use (currently on v1)
-#' @return string; created url for the call
+#' @return list; created url for the call, service type and data item
 #' @family call-building functions
 #' @examples
 #' build_legacy_call(data_item = "FUELINST", api_key = "12345", from_datetime = "14-12-201613:00:00", to_datetime = "14-12-201614:00:00")
@@ -181,80 +187,84 @@ build_legacy_call <- function(data_item, api_key, from_date = NULL, to_date = NU
                               is_two_day_window = NULL, from_datetime = NULL, to_datetime = NULL, from_settlement_date = NULL, to_settlement_date = NULL,
                               period = NULL, fuel_type = NULL, balancing_service_volume = NULL, zone_identifier = NULL, start_time = NULL, end_time = NULL,
                               trade_name = NULL, trade_type = NULL, api_version = "v1", service_type = "csv"){
+  request <- list()
   check_data_item(data_item, "Legacy")
-  url = paste0("https://api.bmreports.com/BMRS/", data_item, "/", api_version, "?APIKey=", api_key)
+  request$url = paste0("https://api.bmreports.com/BMRS/", data_item, "/", api_version, "?APIKey=", api_key)
   if (!is.null(from_date)) {
-    url = paste0(url, "&FromDate=", format_date(from_date))
+    request$url = paste0(request$url, "&FromDate=", format_date(from_date))
   }
   if (!is.null(to_date)) {
-    url = paste0(url, "&ToDate=", format_date(to_date))
+    request$url = paste0(request$url, "&ToDate=", format_date(to_date))
   }
   if (!is.null(settlement_date)) {
-    url = paste0(url, "&SettlementDate=", format_date(settlement_date))
+    request$url = paste0(request$url, "&SettlementDate=", format_date(settlement_date))
   }
   if (!is.null(settlement_period)){
-    url = paste0(url, "&SettlementPeriod=", settlement_period)
+    request$url = paste0(request$url, "&SettlementPeriod=", settlement_period)
   }
   if (!is.null(bm_unit_id)){
-    url = paste0(url, "&BMUnitID=", bm_unit_id)
+    request$url = paste0(request$url, "&BMUnitID=", bm_unit_id)
   }
   if (!is.null(bm_unit_type)){
-    url = paste0(url, "&BMUnitType=", bm_unit_type)
+    request$url = paste0(request$url, "&BMUnitType=", bm_unit_type)
   }
   if (!is.null(lead_party_name)){
-    url = paste0(url, "&LeadPartName=", lead_party_name)
+    request$url = paste0(request$url, "&LeadPartName=", lead_party_name)
   }
   if (!is.null(ngc_bm_unit_name)){
-    url = paste0(url, "&NGCBMUnitName=", ngc_bm_unit_name)
+    request$url = paste0(request$url, "&NGCBMUnitName=", ngc_bm_unit_name)
   }
   if (!is.null(from_cleared_date)){
-    url = paste0(url, "&FromClearedDate=", format_date(from_cleared_date))
+    request$url = paste0(request$url, "&FromClearedDate=", format_date(from_cleared_date))
   }
   if (!is.null(to_cleared_date)){
-    url = paste0(url, "&ToClearedDate=", format_date(to_cleared_date))
+    request$url = paste0(request$url, "&ToClearedDate=", format_date(to_cleared_date))
   }
   if (!is.null(is_two_day_window)){
-    url = paste0(url, "&IsTwoDayWindow=", is_two_day_window)
+    request$url = paste0(request$url, "&IsTwoDayWindow=", is_two_day_window)
   }
   if (!is.null(from_datetime)){
-    url = paste0(url, "&FromDateTime=", format_datetime(from_datetime))
+    request$url = paste0(request$url, "&FromDateTime=", format_datetime(from_datetime))
   }
   if (!is.null(to_datetime)){
-    url = paste0(url, "&ToDateTime=", format_datetime(to_datetime))
+    request$url = paste0(request$url, "&ToDateTime=", format_datetime(to_datetime))
   }
   if (!is.null(from_settlement_date)){
-    url = paste0(url, "&FromSettlementDate=", format_date(from_settlement_date))
+    request$url = paste0(request$url, "&FromSettlementDate=", format_date(from_settlement_date))
   }
   if (!is.null(to_settlement_date)){
-    url = paste0(url, "&ToSettlementDate=", format_date(to_settlement_date))
+    request$url = paste0(request$url, "&ToSettlementDate=", format_date(to_settlement_date))
   }
   if (!is.null(period)){
-    url = paste0(url, "&Period=", period)
+    request$url = paste0(request$url, "&Period=", period)
   }
   if (!is.null(fuel_type)){
-    url = paste0(url, "&FuelType=", fuel_type)
+    request$url = paste0(request$url, "&FuelType=", fuel_type)
   }
   if (!is.null(balancing_service_volume)){
-    url = paste0(url, "&BalancingServiceVolume=", balancing_service_volume)
+    request$url = paste0(request$url, "&BalancingServiceVolume=", balancing_service_volume)
   }
   if (!is.null(zone_identifier)){
-    url = paste0(url, "&ZoneIdentifier=", zone_identifier)
+    request$url = paste0(request$url, "&ZoneIdentifier=", zone_identifier)
   }
   if (!is.null(start_time)){
-    url = paste0(url, "&StartTime=", format_time(start_time))
+    request$url = paste0(request$url, "&StartTime=", format_time(start_time))
   }
   if (!is.null(end_time)){
-    url = paste0(url, "&EndTime=", format_time(end_time))
+    request$url = paste0(request$url, "&EndTime=", format_time(end_time))
   }
   if (!is.null(trade_name)){
-    url = paste0(url, "&TradeName=", trade_name)
+    request$url = paste0(request$url, "&TradeName=", trade_name)
   }
   if (!is.null(trade_type)){
-    url = paste0(url, "&TradeType=", trade_type)
+    request$url = paste0(request$url, "&TradeType=", trade_type)
   }
   if (!is.null(service_type)){
-    url = paste0(url, "&ServiceType=", service_type)
+    request$url = paste0(request$url, "&ServiceType=", service_type)
   }
+  request$service_type <- service_type
+  request$data_item <- data_item
+  return(request)
 }
 
 #' Build an API call (uses the appropriate function based on the data item)
@@ -296,11 +306,11 @@ build_call <- function(data_item, api_key, service_type = "csv", api_version = "
     for (i in 1:length(prov_params)){
       print(names(prov_params[i]))
       if (names(prov_params)[i] %!in% allowed_params){
-        stop("invalid parameter supplied for chosen data item")
+        stop(paste("invalid parameter:", names(prov_params[i]), "supplied for chosen data item"))
       }
     }
   }
   typed_call <- get_function(data_item)
-  url <- do.call(what = typed_call, args = c(data_item = data_item, api_key = api_key, service_type = service_type, api_version = api_version, prov_params))
-  return(url)
+  request <- do.call(what = typed_call, args = c(data_item = data_item, api_key = api_key, service_type = service_type, api_version = api_version, prov_params))
+  return(request)
 }

--- a/R/main.R
+++ b/R/main.R
@@ -10,16 +10,10 @@
 
 full_request <- function(..., get_params = list(), parse = TRUE){
   d_item <- list(...)[['data_item']]
-  if (is.null(list(...)[['service_type']])){
-    s_type = "csv"
-  }
-  else {
-    s_type <- list(...)[['service_type']]
-  }
-  url <- do.call(build_call, args = list(...))
-  results <- send_request(url, d_item, get_params)
+  request <- do.call(build_call, args = list(...))
+  results <- send_request(request$url, request$data_item, get_params)
   if (parse == TRUE){
-    ret <- parse_response(results, format = s_type)
+    ret <- parse_response(results, format = request$service_type)
   } else {
     ret <- results
   }

--- a/tests/testthat/test_build.R
+++ b/tests/testthat/test_build.R
@@ -16,10 +16,10 @@ test_that("Missing arguments", {
 })
 
 test_that("Build output", {
-  expect_type(build_call(data_item = "B1030", api_key = "test"), "character")
-  expect_type(build_b_call(data_item = "B1030", api_key = "test"), "character")
-  expect_type(build_remit_call(data_item = "MessageDetailRetrieval", api_key = "test"), "character")
-  expect_type(build_legacy_call(data_item = "FLOW", api_key = "test"), "character")
+  expect_true(is.list(build_call(data_item = "B1030", api_key = "test")))
+  expect_true(is.list(build_b_call(data_item = "B1030", api_key = "test")))
+  expect_true(is.list(build_remit_call(data_item = "MessageDetailRetrieval", api_key = "test")))
+  expect_true(is.list(build_legacy_call(data_item = "FLOW", api_key = "test")))
 })
 
 

--- a/tests/testthat/test_dates.R
+++ b/tests/testthat/test_dates.R
@@ -1,22 +1,22 @@
 context("Dates, time and datetimes formats")
 
 test_that("Date format correct", {
-  expect_match(build_call(data_item = "B1730", api_key = "test", settlement_date = "12 Jun 2018"), "&SettlementDate=2018-06-12")
-  expect_match(build_call(data_item = "B1730", api_key = "test", settlement_date = "12 06 2018"), "&SettlementDate=2018-06-12")
-  expect_match(build_call(data_item = "B1730", api_key = "test", settlement_date = "12/06/2018"), "&SettlementDate=2018-06-12")
-  expect_match(build_call(data_item = "B1730", api_key = "test", settlement_date = "12-Jun-2018"), "&SettlementDate=2018-06-12")
+  expect_match(build_call(data_item = "B1730", api_key = "test", settlement_date = "12 Jun 2018")$url, "&SettlementDate=2018-06-12")
+  expect_match(build_call(data_item = "B1730", api_key = "test", settlement_date = "12 06 2018")$url, "&SettlementDate=2018-06-12")
+  expect_match(build_call(data_item = "B1730", api_key = "test", settlement_date = "12/06/2018")$url, "&SettlementDate=2018-06-12")
+  expect_match(build_call(data_item = "B1730", api_key = "test", settlement_date = "12-Jun-2018")$url, "&SettlementDate=2018-06-12")
 })
 
 test_that("Time format correct",{
-  expect_match(build_call(data_item = "B1010", api_key = "test", end_time = "125055"), "&EndTime=12:50:55")
-  expect_match(build_call(data_item = "B1010", api_key = "test", end_time = "12:50:55"), "&EndTime=12:50:55")
-  expect_match(build_call(data_item = "B1010", api_key = "test", end_time = "12-50-55"), "&EndTime=12:50:55")
+  expect_match(build_call(data_item = "B1010", api_key = "test", end_time = "125055")$url, "&EndTime=12:50:55")
+  expect_match(build_call(data_item = "B1010", api_key = "test", end_time = "12:50:55")$url, "&EndTime=12:50:55")
+  expect_match(build_call(data_item = "B1010", api_key = "test", end_time = "12-50-55")$url, "&EndTime=12:50:55")
 })
 
 test_that("Datetime format correct", {
-  expect_match(build_call(data_item = "FREQ", api_key = "test", from_datetime = "12 Jun 2018 12:50:55"), "&FromDateTime=2018-06-1212:50:55")
-  expect_match(build_call(data_item = "FREQ", api_key = "test", from_datetime = "12-Jun-2018 125055"), "&FromDateTime=2018-06-1212:50:55")
-  expect_match(build_call(data_item = "FREQ", api_key = "test", from_datetime = "12Jun2018 125055"), "&FromDateTime=2018-06-1212:50:55")
+  expect_match(build_call(data_item = "FREQ", api_key = "test", from_datetime = "12 Jun 2018 12:50:55")$url, "&FromDateTime=2018-06-1212:50:55")
+  expect_match(build_call(data_item = "FREQ", api_key = "test", from_datetime = "12-Jun-2018 125055")$url, "&FromDateTime=2018-06-1212:50:55")
+  expect_match(build_call(data_item = "FREQ", api_key = "test", from_datetime = "12Jun2018 125055")$url, "&FromDateTime=2018-06-1212:50:55")
 })
 
 test_that("Month format warning", {

--- a/tests/testthat/test_return.R
+++ b/tests/testthat/test_return.R
@@ -4,6 +4,10 @@ context("Return accuracy")
 test_that("Returns list", {
   expect_true(tibble::is_tibble(full_request(data_item = "B1720", api_key = "test", settlement_date = "12 Jun 2018", period = "1", service_type = "csv")))
   expect_true(is.list(full_request(data_item = "B1720", api_key = "test", settlement_date = "12 Jun 2018", period = "1", service_type = "xml")))
+  expect_true(is.list(full_request(data_item = "MessageListRetrieval", api_key = "test", event_start = "12 Jun 2018", service_type = "csv")))
+  expect_true(is.list(full_request(data_item = "MessageListRetrieval", api_key = "test", event_start = "12 Jun 2018", service_type = "xml")))
+  expect_true(tibble::is_tibble(full_request(data_item = "TEMP", api_key = "test", from_date = "12 Jun 2018", service_type = "csv")))
+  expect_true(is.list(full_request(data_item = "TEMP", api_key = "test", from_date = "12 Jun 2018", service_type = "xml")))
 })
 
 


### PR DESCRIPTION
Changed return value to a list including the url, service type and data item. This was done to avoid changes made to the service type (i.e. if the user specified "csv" for a REMIT call, it would be automatically changed to "xml") that were not propagated throughout the function calls.